### PR TITLE
make be able to add more than one endpoint to engine service

### DIFF
--- a/src/html/js/registerFileAsService.js
+++ b/src/html/js/registerFileAsService.js
@@ -298,7 +298,7 @@ registerFileAsService.prototype.getEngineSubject = function() {
 	var response = restAdapter.propfind(path);
 	var xmlContent = response.httpClient.responseText;
 	try {
-		return xmlContent.match(/subject=\"(.+?)\"/)[1];
+		return xmlContent.match(/subject=\"([^\"]+?)\"/)[1];
 	} catch (e) {
 		return "";
 	}


### PR DESCRIPTION

#156

I modified erroneous regexp in `registerFileAsService.prototype.getEngineSubject` function . 

https://github.com/personium/app-uc-unit-manager/blob/15ada8b1f1e91fe34b1fe65017a830a74b6708ba/src/html/js/registerFileAsService.js#L291-L306

For example, if `xmlContent` contains below text, 

```
<p:service language="JavaScript" subject="" xmlns:p="urn:x-personium:xmlns" xmlns:D="DAV:" xmlns:Z="http://www.w3.com/standards/z39.50/">
```

then the regexp `/subject=\"(.+?)\"/` matches with 

```
" xmlns:p=
```

because it does not match empty string `""` and matches all characters.

The erroneous match causes problems such as #156 (see the below code)

https://github.com/personium/app-uc-unit-manager/blob/efb024f89d410ced064865f22e8ff02d1df153d0/src/html/js/main/http/RestAdapter.js#L492 


So, I modify the regexp to force not to match double-quotation (").

Could you review it? thanks.